### PR TITLE
Fix null safety crash and silent exception swallowing in TransactionsRepository

### DIFF
--- a/app/src/main/java/com/samourai/sentinel/data/repository/TransactionsRepository.kt
+++ b/app/src/main/java/com/samourai/sentinel/data/repository/TransactionsRepository.kt
@@ -163,8 +163,9 @@ class TransactionsRepository {
             saveTx(newTransactions, collectionId)
             saveUtxos(utxos, collectionId)
         } catch (e: Exception) {
-            if (!e.message?.lowercase()!!.contains("unable to resolve host")
-                && !e.message?.lowercase()!!.contains("standalonecoroutine was cancelled")) {
+            val msg = e.message?.lowercase().orEmpty()
+            if (!msg.contains("unable to resolve host")
+                && !msg.contains("standalonecoroutine was cancelled")) {
                     apiScope.launch(Dispatchers.Main) {
                         loading.value = loading.value?.apply { remove(true) }
                     }
@@ -290,8 +291,9 @@ class TransactionsRepository {
             }
 
             saveUtxos(utxos, collectionId)
-        } catch (_: Exception) {
         } catch (e: ApiNotConfigured) {
+            Timber.e(e)
+        } catch (e: Exception) {
             Timber.e(e)
         }
     }


### PR DESCRIPTION
## Summary

Two bug fixes in `TransactionsRepository.kt`:

**1. Null safety crash in `fetchFromServer` (line 166)**

`e.message?.lowercase()!!` crashes with `NullPointerException` when the exception has a null message. Many standard exceptions (e.g., `NullPointerException`, `CancellationException`) can have null messages, so this is a real crash path during network error handling.

**Fix:** Extract to a local variable with `.orEmpty()` for null-safe access. Also avoids calling `lowercase()` twice.

**2. Silent exception swallowing in `fetchUTXOS` (line 293)**

`catch (_: Exception) {}` silently drops all exceptions — network errors, JSON parse failures, and DB errors all vanish with no logging. This makes debugging production issues very difficult.

**Fix:** Add `Timber.e(e)` logging and reorder catch blocks so `ApiNotConfigured` is caught first for clarity.

Both fixes are mechanical and isolated to one file with no behavioral side effects beyond preventing crashes and adding log visibility.