### PR TITLE
Remove runBlocking calls that block the main thread

### DIFF
--- a/app/src/main/java/com/samourai/sentinel/ui/MainActivity.kt
+++ b/app/src/main/java/com/samourai/sentinel/ui/MainActivity.kt
@@ -13,6 +13,7 @@ import com.samourai.sentinel.ui.dojo.DojoUtility
 import com.samourai.sentinel.ui.home.HomeActivity
 import com.samourai.sentinel.ui.utils.PrefsUtil
 import com.samourai.sentinel.ui.views.LockScreenDialog
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.*
 import org.koin.java.KoinJavaComponent.inject
 import timber.log.Timber
@@ -44,7 +45,7 @@ class MainActivity : AppCompatActivity() {
             lockScreenDialog.setOnPinEntered {
                 if (AccessFactory.getInstance(this).validateHash(it, pinHash)) {
                     accessFactory.pin = it
-                    runBlocking {
+                    lifecycleScope.launch {
                         delay(100)
                         dojoUtil.read()
                         navigate()

--- a/app/src/main/java/com/samourai/sentinel/ui/tools/sweep/SweepPrivKeyFragment.kt
+++ b/app/src/main/java/com/samourai/sentinel/ui/tools/sweep/SweepPrivKeyFragment.kt
@@ -558,12 +558,10 @@ class PreviewBottomSheet(private var selectedCollection: PubKeyCollection? = nul
             val hexTx = broadcastTx()
             var response: String? = null
             apiScope.launch {
-                runBlocking {
-                    try {
-                        response = apiService.broadcast(hexTx!!)
-                    } catch (e: Exception) {
-                        Log.d("SweepPrivateKey", "Error broadcasting tx: " + e)
-                    }
+                try {
+                    response = apiService.broadcast(hexTx!!)
+                } catch (e: Exception) {
+                    Log.d("SweepPrivateKey", "Error broadcasting tx: " + e)
                 }
 
                 requireActivity().runOnUiThread {


### PR DESCRIPTION
## Summary

Removes two `runBlocking` usages that either block the main thread or are redundant:

**1. MainActivity.kt — ANR risk on PIN entry**

`runBlocking` in the `setOnPinEntered` callback freezes the main thread while waiting on `delay(100)`. Replaced with `lifecycleScope.launch` which runs the same logic without blocking. `dojoUtil.read()` is not a suspend function (it launches its own coroutine internally), so no behavioral change beyond unblocking the UI thread.

**2. SweepPrivKeyFragment.kt — redundant wrapper in broadcast**

`runBlocking` inside `apiScope.launch` is unnecessary since we're already executing in a coroutine. The wrapper blocks the IO thread for no reason. Removed it so the coroutine runs naturally.

Two other `runBlocking` usages were reviewed and intentionally left alone:
- `TokenAuthenticator.kt` — OkHttp's `Authenticator` interface is synchronous by design; `runBlocking` is the standard bridge pattern here.
- `SweepPrivKeyFragment.kt:173` — has pre-existing threading concerns that warrant a separate fix.