### PR TITLE
Replace GlobalScope with lifecycleScope across UI components

### DIFF
--- a/app/src/main/java/com/samourai/sentinel/ui/broadcast/BroadcastTx.kt
+++ b/app/src/main/java/com/samourai/sentinel/ui/broadcast/BroadcastTx.kt
@@ -34,7 +34,7 @@ import com.sparrowwallet.hummingbird.registry.CryptoPSBT
 import com.sparrowwallet.hummingbird.registry.RegistryType
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -304,7 +304,7 @@ class ScanTxFragment : BottomSheetDialogFragment() {
         mCodeScanner.setLifeCycleOwner(this)
 
         mCodeScanner.setQRDecodeListener {
-            GlobalScope.launch(Dispatchers.Main) {
+            lifecycleScope.launch {
                     onScan(it)
             }
         }

--- a/app/src/main/java/com/samourai/sentinel/ui/collectionDetails/CollectionDetailsActivity.kt
+++ b/app/src/main/java/com/samourai/sentinel/ui/collectionDetails/CollectionDetailsActivity.kt
@@ -21,8 +21,7 @@ import com.samourai.sentinel.ui.collectionDetails.send.SendFragment
 import com.samourai.sentinel.ui.collectionDetails.transactions.TransactionsFragment
 import com.samourai.sentinel.ui.utils.showFloatingSnackBar
 import com.samourai.wallet.util.XPUB
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.java.KoinJavaComponent.inject
@@ -134,7 +133,7 @@ class CollectionDetailsActivity : SentinelActivity(), TransactionsFragment.OnTab
         })
 
         binding.fragmentHostContainerPager.visibility = View.INVISIBLE
-        GlobalScope.launch(Dispatchers.Main) {
+        lifecycleScope.launch {
             delay(1)
             binding.fragmentHostContainerPager.setCurrentItem(1, false)
             binding.fragmentHostContainerPager.visibility = View.VISIBLE

--- a/app/src/main/java/com/samourai/sentinel/ui/dojo/DojoConfigureBottomSheet.kt
+++ b/app/src/main/java/com/samourai/sentinel/ui/dojo/DojoConfigureBottomSheet.kt
@@ -35,7 +35,7 @@ import com.samourai.sentinel.util.FormatsUtil
 import com.samourai.sentinel.util.apiScope
 import com.samourai.wallet.util.FormatsUtilGeneric
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -392,7 +392,7 @@ class ScanFragment : Fragment() {
         view.findViewById<TextView>(R.id.scanInstructions).text = getString(R.string.dojo_scan_instruction)
         view.findViewById<TextView>(R.id.scanInstructions).textAlignment = TextView.TEXT_ALIGNMENT_CENTER
         mCodeScanner?.setQRDecodeListener {
-            GlobalScope.launch(Dispatchers.Main) {
+            lifecycleScope.launch {
                 mCodeScanner?.stopScanner()
                 onScan(it)
             }

--- a/app/src/main/java/com/samourai/sentinel/ui/fragments/AddNewPubKeyBottomSheet.kt
+++ b/app/src/main/java/com/samourai/sentinel/ui/fragments/AddNewPubKeyBottomSheet.kt
@@ -45,7 +45,7 @@ import com.sparrowwallet.hummingbird.registry.CryptoAccount
 import com.sparrowwallet.hummingbird.registry.PathComponent
 import com.sparrowwallet.hummingbird.registry.RegistryType
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.bitcoinj.crypto.ChildNumber
@@ -281,7 +281,7 @@ class ScanPubKeyFragment : Fragment() {
 
         val clipboard = context?.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         mCodeScanner.setQRDecodeListener {
-            GlobalScope.launch(Dispatchers.Main) {
+            lifecycleScope.launch {
                 mCodeScanner.stopScanner()
                 onScan(it)
             }

--- a/app/src/main/java/com/samourai/sentinel/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/samourai/sentinel/ui/home/HomeActivity.kt
@@ -45,10 +45,8 @@ import com.samourai.sentinel.util.MonetaryUtil
 import com.samourai.sentinel.util.TimeOutUtil
 import com.samourai.sentinel.util.UtxoMetaUtil
 import com.samourai.sentinel.widgets.popUpMenu.popupMenu
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.koin.java.KoinJavaComponent.inject
 
 
@@ -250,10 +248,8 @@ class HomeActivity : SentinelActivity() {
             } else {
                 SentinelTorManager.getTorStateLiveData().observe(this, {
                     if (it.state == EnumTorState.ON) {
-                        GlobalScope.launch {
-                            withContext(Dispatchers.Main) {
-                                model.fetchBalance()
-                            }
+                        lifecycleScope.launch {
+                            model.fetchBalance()
                         }
                     }
                 })

--- a/app/src/main/java/com/samourai/sentinel/ui/tools/sweep/SweepPrivKeyFragment.kt
+++ b/app/src/main/java/com/samourai/sentinel/ui/tools/sweep/SweepPrivKeyFragment.kt
@@ -72,7 +72,7 @@ import com.samourai.wallet.util.TxUtil
 import com.samourai.wallet.util.XPUB
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
@@ -956,7 +956,7 @@ class ScanPrivKeyFragment : BottomSheetDialogFragment() {
         mCodeScanner.setLifeCycleOwner(this)
 
         mCodeScanner.setQRDecodeListener {
-            GlobalScope.launch(Dispatchers.Main) {
+            lifecycleScope.launch {
                 onScan(it)
             }
         }


### PR DESCRIPTION
## Summary

Replaces all 6 `GlobalScope.launch` usages in UI components with `lifecycleScope.launch`.

`GlobalScope` creates coroutines that outlive the Activity/Fragment lifecycle — if the user navigates away, the coroutine keeps running, leaking memory and potentially crashing when it accesses destroyed views. `lifecycleScope` ties the coroutine to the component's lifecycle and auto-cancels on destroy.

**Files changed (6):**
- `HomeActivity.kt` — also removed unnecessary `withContext(Dispatchers.Main)` wrapper since `lifecycleScope` already runs on Main
- `CollectionDetailsActivity.kt`
- `BroadcastTx.kt`
- `AddNewPubKeyBottomSheet.kt`
- `SweepPrivKeyFragment.kt`
- `DojoConfigureBottomSheet.kt`

All changes are 1:1 replacements with no behavioral change beyond proper lifecycle management. Cleaned up unused `Dispatchers` and `withContext` imports where applicable.