### PR TITLE
Fix typo and replace raw logging with proper frameworks

### DIFF
--- a/app/src/main/java/com/samourai/sentinel/data/repository/TransactionsRepository.kt
+++ b/app/src/main/java/com/samourai/sentinel/data/repository/TransactionsRepository.kt
@@ -159,7 +159,7 @@ class TransactionsRepository {
                 utxoDao.deleteByCollection(collectionId)
                 txDao.deleteByCollectionID(collectionId)
             }
-            newTransactions = keepTransactionWihVariousPubkeys(newTransactions)
+            newTransactions = keepTransactionWithVariousPubkeys(newTransactions)
             saveTx(newTransactions, collectionId)
             saveUtxos(utxos, collectionId)
         } catch (e: Exception) {
@@ -174,7 +174,7 @@ class TransactionsRepository {
         }
     }
 
-    private fun keepTransactionWihVariousPubkeys(transactions: ArrayList<Tx>): ArrayList<Tx> {
+    private fun keepTransactionWithVariousPubkeys(transactions: ArrayList<Tx>): ArrayList<Tx> {
         val groupedTransactions = transactions.groupBy { it.hash }
         val hashes: HashMap<String, Int> = hashMapOf()
         groupedTransactions.forEach {

--- a/app/src/main/java/com/samourai/sentinel/ui/utils/OnSwipeTouchListener.java
+++ b/app/src/main/java/com/samourai/sentinel/ui/utils/OnSwipeTouchListener.java
@@ -5,6 +5,8 @@ import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
 
+import timber.log.Timber;
+
 public class OnSwipeTouchListener implements View.OnTouchListener {
 
     private final GestureDetector gestureDetector;
@@ -53,7 +55,7 @@ public class OnSwipeTouchListener implements View.OnTouchListener {
                     result = true;
                 }
             } catch (Exception exception) {
-                exception.printStackTrace();
+                Timber.e(exception);
             }
             return result;
         }

--- a/app/src/main/java/com/samourai/sentinel/util/AddressFactory.java
+++ b/app/src/main/java/com/samourai/sentinel/util/AddressFactory.java
@@ -12,6 +12,8 @@ import com.samourai.sentinel.core.hd.HD_WalletFactory;
 import java.io.IOException;
 import java.util.HashMap;
 
+import timber.log.Timber;
+
 public class AddressFactory {
 
     public static final int LOOKAHEAD_GAP = 20;
@@ -73,11 +75,11 @@ public class AddressFactory {
             }
         }
         catch(IOException ioe)	{
-            ioe.printStackTrace();
+            Timber.e(ioe);
             Toast.makeText(context, "HD wallet error", Toast.LENGTH_SHORT).show();
         }
         catch(MnemonicException.MnemonicLengthException mle)	{
-            mle.printStackTrace();
+            Timber.e(mle);
             Toast.makeText(context, "HD wallet error", Toast.LENGTH_SHORT).show();
         }
 
@@ -98,11 +100,11 @@ public class AddressFactory {
             }
         }
         catch(IOException ioe)	{
-            ioe.printStackTrace();
+            Timber.e(ioe);
             Toast.makeText(context, "HD wallet error", Toast.LENGTH_SHORT).show();
         }
         catch(MnemonicException.MnemonicLengthException mle)	{
-            mle.printStackTrace();
+            Timber.e(mle);
             Toast.makeText(context, "HD wallet error", Toast.LENGTH_SHORT).show();
         }
 
@@ -118,11 +120,11 @@ public class AddressFactory {
             addr = HD_WalletFactory.getInstance(context).get().getAccount(accountIdx).getChain(chain).getAddressAt(idx);
         }
         catch(IOException ioe)	{
-            ioe.printStackTrace();
+            Timber.e(ioe);
             Toast.makeText(context, "HD wallet error", Toast.LENGTH_SHORT).show();
         }
         catch(MnemonicException.MnemonicLengthException mle)	{
-            mle.printStackTrace();
+            Timber.e(mle);
             Toast.makeText(context, "HD wallet error", Toast.LENGTH_SHORT).show();
         }
 

--- a/app/src/main/java/com/samourai/sentinel/util/AppUtil.java
+++ b/app/src/main/java/com/samourai/sentinel/util/AppUtil.java
@@ -6,7 +6,7 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.text.InputType;
-import android.util.Log;
+import timber.log.Timber;
 import android.widget.EditText;
 import android.widget.Toast;
 
@@ -82,12 +82,12 @@ public class AppUtil {
         ActivityManager manager = (ActivityManager)context.getSystemService(Context.ACTIVITY_SERVICE);
         for (ActivityManager.RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
             if (serviceClass.getName().equals(service.service.getClassName())) {
-                Log.d("AppUtil", "service class name:" + serviceClass.getName() + " is running");
+                Timber.d("service class name: %s is running", serviceClass.getName());
                 return true;
             }
         }
 
-        Log.d("AppUtil", "service class name:" + serviceClass.getName() + " is not running");
+        Timber.d("service class name: %s is not running", serviceClass.getName());
         return false;
     }
 

--- a/app/src/main/java/com/samourai/sentinel/util/FootprintUtil.java
+++ b/app/src/main/java/com/samourai/sentinel/util/FootprintUtil.java
@@ -3,7 +3,8 @@ package com.samourai.sentinel.util;
 import android.content.Context;
 import android.os.Build;
 import android.telephony.TelephonyManager;
-//import android.util.Log;
+
+import timber.log.Timber;
 
 import org.bouncycastle.crypto.digests.RIPEMD160Digest;
 import org.bouncycastle.util.encoders.Hex;
@@ -54,7 +55,7 @@ public class FootprintUtil {
                 return new String(Hex.encode(out));
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            Timber.e(e);
         }
 
         return strFootprint;

--- a/extlibj/src/main/java/com/samourai/wallet/bip47/rpc/obpp05/PaymentAddress.java
+++ b/extlibj/src/main/java/com/samourai/wallet/bip47/rpc/obpp05/PaymentAddress.java
@@ -8,6 +8,9 @@ import org.bouncycastle.crypto.ec.CustomNamedCurves;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.math.ec.ECPoint;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -20,6 +23,8 @@ import java.security.spec.InvalidKeySpecException;
 import com.samourai.wallet.util.Util;
 
 public class PaymentAddress {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentAddress.class);
 
     private PaymentCode paymentCode = null;
     private int index = 0;
@@ -174,7 +179,7 @@ public class PaymentAddress {
         // check that 's' is on the secp256k1 curve
         //
         if(!isSecp256k1(s))    {
-            System.out.println("Secret point not on secp256k1 curve");
+            log.warn("Secret point not on secp256k1 curve");
             return null;
         }
 


### PR DESCRIPTION
## Summary

Bundle of small cleanup fixes — no behavioral changes.

**Typo fix:**
- `keepTransactionWihVariousPubkeys` → `keepTransactionWithVariousPubkeys` (private method in TransactionsRepository)

**Logging standardization (app/):**
- Replaced 6x `printStackTrace()` with `Timber.e()` in AddressFactory, FootprintUtil, OnSwipeTouchListener
- Replaced 2x `Log.d()` with `Timber.d()` in AppUtil
- `printStackTrace()` writes to logcat with no tag filtering, is hard to grep in production logs, and is flagged by Android lint. Timber is already the project's standard logging framework.

**Logging standardization (extlibj/):**
- Replaced `System.out.println("Secret point not on secp256k1 curve")` with SLF4J logger in `obpp05/PaymentAddress.java`
- Used SLF4J (not Timber) since extlibj is a pure Java library, consistent with other classes in the package (PaymentCode.java, Bip47PartnerImpl.java)